### PR TITLE
fix(custom-provider): wire base_url_override end-to-end and harden retries

### DIFF
--- a/src/api/api_key_checker.py
+++ b/src/api/api_key_checker.py
@@ -17,6 +17,11 @@
 # src/api/api_key_checker.py
 from src.api.provider_manager import (check_api_keys_status as provider_check_api_keys_status,get_default_provider,)
 
-def check_api_keys_status(api_keys, model=None, provider=None):
+def check_api_keys_status(api_keys, model=None, provider=None, base_url_override=None):
     provider_name = provider or get_default_provider()
-    return provider_check_api_keys_status(provider_name, api_keys, model=model)
+    return provider_check_api_keys_status(
+        provider_name,
+        api_keys,
+        model=model,
+        base_url_override=base_url_override,
+    )

--- a/src/api/openrouter_api.py
+++ b/src/api/openrouter_api.py
@@ -23,6 +23,7 @@ import os
 import threading
 import time
 from typing import Dict, Iterable, List, Optional, Tuple, Union
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 import re
@@ -354,15 +355,16 @@ def _resolve_chat_endpoint(base_url_override: Optional[str]) -> str:
 	When ``base_url_override`` is empty/None we fall back to the OpenRouter
 	default. Otherwise we accept either a bare base URL (``https://host/v1``)
 	or a fully-qualified chat endpoint (``https://host/v1/chat/completions``)
-	and normalise to the latter.
+	and normalise to the latter while preserving query strings and fragments.
 	"""
 	candidate = (base_url_override or "").strip()
 	if not candidate:
 		return API_ENDPOINT
-	normalised = candidate.rstrip("/")
-	if normalised.endswith(_DEFAULT_CHAT_PATH):
-		return normalised
-	return f"{normalised}{_DEFAULT_CHAT_PATH}"
+	parts = urlsplit(candidate)
+	path = parts.path.rstrip("/")
+	if not path.endswith(_DEFAULT_CHAT_PATH):
+		path = f"{path}{_DEFAULT_CHAT_PATH}"
+	return urlunsplit((parts.scheme, parts.netloc, path, parts.query, parts.fragment))
 
 
 def get_openrouter_metadata(
@@ -383,7 +385,7 @@ def get_openrouter_metadata(
 		log_message(error_message or "Invalid image for OpenRouter request", "warning")
 		return {"error": error_message or "unsupported_image_format"}
 
-	if check_stop_event(stop_event, "OpenRouter request cancelled before submission"):
+	if check_stop_event(stop_event, "Metadata request cancelled before submission"):
 		return "stopped"
 
 	endpoint_url = _resolve_chat_endpoint(base_url_override)

--- a/src/api/openrouter_api.py
+++ b/src/api/openrouter_api.py
@@ -33,6 +33,7 @@ from src.utils.json_utils import _clean_json_text
 from src.utils.stop_flag import is_stop_requested
 
 API_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
+_DEFAULT_CHAT_PATH = "/chat/completions"
 API_TIMEOUT = 60
 API_MAX_RETRIES = 2
 RETRY_DELAY_SECONDS = 8
@@ -347,6 +348,23 @@ def _validate_images(images: Iterable[str]) -> Tuple[bool, Optional[str]]:
 	return True, None
 
 
+def _resolve_chat_endpoint(base_url_override: Optional[str]) -> str:
+	"""Build the chat-completions URL for the active provider.
+
+	When ``base_url_override`` is empty/None we fall back to the OpenRouter
+	default. Otherwise we accept either a bare base URL (``https://host/v1``)
+	or a fully-qualified chat endpoint (``https://host/v1/chat/completions``)
+	and normalise to the latter.
+	"""
+	candidate = (base_url_override or "").strip()
+	if not candidate:
+		return API_ENDPOINT
+	normalised = candidate.rstrip("/")
+	if normalised.endswith(_DEFAULT_CHAT_PATH):
+		return normalised
+	return f"{normalised}{_DEFAULT_CHAT_PATH}"
+
+
 def get_openrouter_metadata(
 	image_path: Union[str, List[str]],
 	api_key: str,
@@ -357,6 +375,7 @@ def get_openrouter_metadata(
 	keyword_count: Union[str, int] = "49",
 	priority: str = "Detailed",
 	is_vector_conversion: bool = False,
+	base_url_override: Optional[str] = None,
 ):
 	images: List[str] = image_path if isinstance(image_path, list) else [image_path]
 	is_valid, error_message = _validate_images(images)
@@ -367,7 +386,16 @@ def get_openrouter_metadata(
 	if check_stop_event(stop_event, "OpenRouter request cancelled before submission"):
 		return "stopped"
 
-	model_to_use = (selected_model_input or "openai/gpt-4.1").strip()
+	endpoint_url = _resolve_chat_endpoint(base_url_override)
+	provider_label = "Custom" if base_url_override else "OpenRouter"
+	default_model = "openai/gpt-4.1" if not base_url_override else ""
+	model_to_use = (selected_model_input or default_model).strip()
+	if not model_to_use:
+		log_message(
+			f"{provider_label} provider requires a model selection.",
+			"error",
+		)
+		return {"error": "custom_provider_no_model" if base_url_override else "openrouter_no_model"}
 	api_model = model_to_use
 	reasoning_effort = None
 	verbosity = None
@@ -383,7 +411,7 @@ def get_openrouter_metadata(
 
 	attempt = 0
 	while attempt < API_MAX_RETRIES:
-		if check_stop_event(stop_event, "OpenRouter request cancelled during retries"):
+		if check_stop_event(stop_event, f"{provider_label} request cancelled during retries"):
 			return "stopped"
 
 		payload = _build_payload(
@@ -402,18 +430,18 @@ def get_openrouter_metadata(
 			"Content-Type": "application/json",
 			"Accept": "application/json",
 		}
-		if OPENROUTER_HTTP_REFERER:
+		if not base_url_override and OPENROUTER_HTTP_REFERER:
 			headers["HTTP-Referer"] = OPENROUTER_HTTP_REFERER
-		if OPENROUTER_TITLE:
+		if not base_url_override and OPENROUTER_TITLE:
 			headers["X-Title"] = OPENROUTER_TITLE
 
 		try:
 			log_message(
-				f"Sending metadata request to OpenRouter model {model_to_use} (key ...{api_key[-5:]})",
+				f"Sending metadata request to {provider_label} model {model_to_use} (key ...{api_key[-5:]})",
 				"info",
 			)
 			response = requests.post(
-				API_ENDPOINT,
+				endpoint_url,
 				headers=headers,
 				json=payload,
 				timeout=API_TIMEOUT,
@@ -421,14 +449,14 @@ def get_openrouter_metadata(
 		except requests.RequestException as exc:
 			if check_stop_event(stop_event):
 				return "stopped"
-			log_message(f"OpenRouter request failed: {exc}", "error")
+			log_message(f"{provider_label} request failed: {exc}", "error")
 			attempt += 1
 			if attempt >= API_MAX_RETRIES:
 				return {"error": str(exc)}
 			sleep_duration = RETRY_DELAY_SECONDS * attempt
 			sleep_start = time.time()
 			while time.time() - sleep_start < sleep_duration:
-				if check_stop_event(stop_event, "OpenRouter retry sleep cancelled"):
+				if check_stop_event(stop_event, f"{provider_label} retry sleep cancelled"):
 					return "stopped"
 				time.sleep(0.1)
 			continue
@@ -437,7 +465,7 @@ def get_openrouter_metadata(
 			try:
 				response_data = response.json()
 			except json.JSONDecodeError as exc:
-				log_message(f"Failed to decode OpenRouter response JSON: {exc}", "error")
+				log_message(f"Failed to decode {provider_label} response JSON: {exc}", "error")
 				return {"error": "invalid_json"}
 
 			usage_payload = response_data.get("usage") or {}
@@ -449,25 +477,25 @@ def get_openrouter_metadata(
 
 			metadata = _parse_openrouter_response(response_data, keyword_count)
 			if metadata:
-				log_message("Metadata successfully extracted from OpenRouter response", "success")
+				log_message(f"Metadata successfully extracted from {provider_label} response", "success")
 				return metadata
 
-			log_message("OpenRouter response did not include usable metadata", "warning")
+			log_message(f"{provider_label} response did not include usable metadata", "warning")
 			return {"error": "empty_response"}
 
 		if response.status_code in {401, 403}:
-			log_message("OpenRouter authentication error - check API key permissions", "error")
+			log_message(f"{provider_label} authentication error - check API key permissions", "error")
 			return {"error": f"Authentication failed ({response.status_code})"}
 
 		if response.status_code == 429:
 			if check_stop_event(stop_event):
 				return "stopped"
-			log_message("OpenRouter rate limit hit, backing off before retry", "warning")
+			log_message(f"{provider_label} rate limit hit, backing off before retry", "warning")
 			attempt += 1
 			sleep_duration = RETRY_DELAY_SECONDS * attempt
 			sleep_start = time.time()
 			while time.time() - sleep_start < sleep_duration:
-				if check_stop_event(stop_event, "OpenRouter retry sleep cancelled"):
+				if check_stop_event(stop_event, f"{provider_label} retry sleep cancelled"):
 					return "stopped"
 				time.sleep(0.1)
 			continue
@@ -475,12 +503,12 @@ def get_openrouter_metadata(
 		if 500 <= response.status_code < 600:
 			if check_stop_event(stop_event):
 				return "stopped"
-			log_message(f"OpenRouter server error {response.status_code}, retrying", "warning")
+			log_message(f"{provider_label} server error {response.status_code}, retrying", "warning")
 			attempt += 1
 			sleep_duration = RETRY_DELAY_SECONDS * attempt
 			sleep_start = time.time()
 			while time.time() - sleep_start < sleep_duration:
-				if check_stop_event(stop_event, "OpenRouter retry sleep cancelled"):
+				if check_stop_event(stop_event, f"{provider_label} retry sleep cancelled"):
 					return "stopped"
 				time.sleep(0.1)
 			continue
@@ -506,7 +534,7 @@ def get_openrouter_metadata(
 					error_message = fallback_text[:200]
 
 		log_message(
-			f"OpenRouter request failed (HTTP {response.status_code}): {error_message}",
+			f"{provider_label} request failed (HTTP {response.status_code}): {error_message}",
 			"error",
 		)
 		return {"error": error_message or f"http_{response.status_code}"}
@@ -514,9 +542,19 @@ def get_openrouter_metadata(
 	return {"error": "openrouter_max_retries"}
 
 
-def check_api_keys_status(api_keys: Iterable[str], model: Optional[str] = None) -> dict:
+def check_api_keys_status(
+	api_keys: Iterable[str],
+	model: Optional[str] = None,
+	base_url_override: Optional[str] = None,
+) -> dict:
 	results: Dict[str, Tuple[int, str]] = {}
-	test_model = (model or "openai/gpt-4.1").strip()
+	endpoint_url = _resolve_chat_endpoint(base_url_override)
+	default_model = "openai/gpt-4.1" if not base_url_override else ""
+	test_model = (model or default_model).strip()
+	if not test_model:
+		for key in api_keys:
+			results[key] = (-1, "Model required for custom provider key check")
+		return results
 	api_model = test_model
 
 	payload = {
@@ -553,14 +591,14 @@ def check_api_keys_status(api_keys: Iterable[str], model: Optional[str] = None) 
 			"Content-Type": "application/json",
 			"Accept": "application/json",
 		}
-		if OPENROUTER_HTTP_REFERER:
+		if not base_url_override and OPENROUTER_HTTP_REFERER:
 			headers["HTTP-Referer"] = OPENROUTER_HTTP_REFERER
-		if OPENROUTER_TITLE:
+		if not base_url_override and OPENROUTER_TITLE:
 			headers["X-Title"] = OPENROUTER_TITLE
 
 		try:
 			response = requests.post(
-				API_ENDPOINT,
+				endpoint_url,
 				headers=headers,
 				json=payload,
 				timeout=20,

--- a/src/api/provider_manager.py
+++ b/src/api/provider_manager.py
@@ -401,8 +401,6 @@ def check_api_keys_status(
     base_url_override: Optional[str] = None,
 ):
     module, provider_key = get_provider_module(provider)
-    if module is None:
-        return {k: (-1, "No module for this provider") for k in api_keys}
     if provider_key == PROVIDER_CUSTOM:
         effective_base_url = (base_url_override or "").strip()
         if not effective_base_url:
@@ -412,6 +410,8 @@ def check_api_keys_status(
             model=model,
             base_url_override=effective_base_url,
         )
+    if module is None:
+        return {k: (-1, "No module for this provider") for k in api_keys}
     return module.check_api_keys_status(list(api_keys), model=model)
 
 

--- a/src/api/provider_manager.py
+++ b/src/api/provider_manager.py
@@ -265,6 +265,9 @@ def get_metadata(
         if not effective_base_url:
             log_message("Custom provider requires a base_url_override.", "error")
             return {"error": "custom_provider_no_base_url"}
+        if not (effective_model or "").strip():
+            log_message("Custom provider requires a model selection.", "error")
+            return {"error": "custom_provider_no_model"}
         result = openrouter_api.get_openrouter_metadata(
             image_path,
             api_key,
@@ -275,6 +278,7 @@ def get_metadata(
             keyword_count=keyword_count,
             priority=priority,
             is_vector_conversion=is_vector_conversion,
+            base_url_override=effective_base_url,
         )
         if isinstance(result, dict) and "error" not in result:
             return _sanitize_title_length(_fill_keywords_if_short(result, keyword_count))
@@ -390,10 +394,24 @@ def get_metadata(
     return result
 
 
-def check_api_keys_status(provider: str, api_keys: Iterable[str], model: Optional[str] = None):
+def check_api_keys_status(
+    provider: str,
+    api_keys: Iterable[str],
+    model: Optional[str] = None,
+    base_url_override: Optional[str] = None,
+):
     module, provider_key = get_provider_module(provider)
     if module is None:
         return {k: (-1, "No module for this provider") for k in api_keys}
+    if provider_key == PROVIDER_CUSTOM:
+        effective_base_url = (base_url_override or "").strip()
+        if not effective_base_url:
+            return {k: (-1, "Custom provider requires a Base URL") for k in api_keys}
+        return openrouter_api.check_api_keys_status(
+            list(api_keys),
+            model=model,
+            base_url_override=effective_base_url,
+        )
     return module.check_api_keys_status(list(api_keys), model=model)
 
 

--- a/src/processing/batch_processing.py
+++ b/src/processing/batch_processing.py
@@ -31,6 +31,10 @@ from src.processing.image_processing.format_png_processing import process_png
 from src.processing.vector_processing.format_eps_ai_processing import convert_eps_to_jpg
 from src.processing.vector_processing.format_svg_processing import convert_svg_to_jpg
 from src.processing.video_processing import process_video
+from src.processing.error_classifier import (
+    NON_RETRYABLE_ERROR_CODES,
+    classify_metadata_error,
+)
 from src.api import provider_manager
 from src.metadata.csv_exporter import write_to_platform_csvs
 from src.metadata.exif_writer import write_exif_with_exiftool
@@ -47,8 +51,9 @@ RETRYABLE_STATUSES = {
 }
 
 NON_RETRYABLE_STATUSES = {
-    "failed_format", "failed_empty", "failed_input_missing"  
+    "failed_format", "failed_empty", "failed_input_missing", "failed_config"  
 }
+
 
 def is_retryable(status: str, attempt: int) -> bool:
     if status in NON_RETRYABLE_STATUSES:
@@ -175,7 +180,7 @@ def process_vector_file(
         return "stopped", None, None
     elif isinstance(metadata_result, dict) and "error" in metadata_result:
         log_message(f"API Error detail: {metadata_result['error']}")
-        return "failed_api", None, None
+        return classify_metadata_error(metadata_result["error"]), None, None
     elif isinstance(metadata_result, dict):
         metadata = metadata_result
     else:
@@ -827,6 +832,8 @@ def batch_process_files(
                                     log_message(f"✗ {filename} (empty file)", "error")
                                 elif status == "failed_input_missing":
                                      log_message(f"✗ {filename} (input missing)", "error")
+                                elif status == "failed_config":
+                                     log_message(f"✗ {filename} (provider misconfiguration — fix and re-run)", "error")
                                 else: 
                                      log_message(f"✗ {filename} ({status})", "error")
                             

--- a/src/processing/batch_processing.py
+++ b/src/processing/batch_processing.py
@@ -72,6 +72,7 @@ def process_vector_file(
     embedding_enabled=True,
     keyword_count="49",
     priority="Details",
+    base_url_override=None,
 ):
     filename = os.path.basename(input_path)
     _, ext = os.path.splitext(filename)
@@ -160,6 +161,7 @@ def process_vector_file(
         keyword_count=keyword_count,
         priority=priority,
         is_vector_conversion=True,
+        base_url_override=base_url_override,
     )
     
     if temp_raster_path and os.path.exists(temp_raster_path):
@@ -233,6 +235,7 @@ def process_image(
     embedding_enabled=True,
     keyword_count="49",
     priority="Details",
+    base_url_override=None,
 ):
     filename = os.path.basename(input_path)
     _, ext = os.path.splitext(filename)
@@ -260,6 +263,7 @@ def process_image(
             embedding_enabled=embedding_enabled,
             keyword_count=keyword_count,
             priority=priority,
+            base_url_override=base_url_override,
         )
     elif ext_lower in ['.eps', '.ai', '.svg']:
         return process_vector_file(
@@ -274,6 +278,7 @@ def process_image(
             embedding_enabled=embedding_enabled,
             keyword_count=keyword_count,
             priority=priority,
+            base_url_override=base_url_override,
         )
     elif ext_lower in ['.jpg', '.jpeg']:
         from src.processing.image_processing.format_jpg_jpeg_processing import process_jpg_jpeg
@@ -288,6 +293,7 @@ def process_image(
             embedding_enabled=embedding_enabled,
             keyword_count=keyword_count,
             priority=priority,
+            base_url_override=base_url_override,
         )
     else:
         log_message(f"Format file tidak didukung: {ext_lower}")
@@ -308,6 +314,7 @@ def process_single_file(
     priority="Details",
     stop_event=None,
     prompt_config=None,
+    base_url_override=None,
 ):
     if prompt_config is None:
         prompt_config = {}
@@ -395,6 +402,7 @@ def process_single_file(
                 embedding_enabled,
                 keyword_count,
                 priority,
+                base_url_override,
             )
         elif ext_lower in ['.eps', '.ai', '.svg']:
             status, processed_metadata, initial_output_path = process_vector_file(
@@ -409,6 +417,7 @@ def process_single_file(
                 embedding_enabled,
                 keyword_count,
                 priority,
+                base_url_override,
             )
         elif ext_lower in ['.jpg', '.jpeg']:
             from src.processing.image_processing.format_jpg_jpeg_processing import process_jpg_jpeg
@@ -423,6 +432,7 @@ def process_single_file(
                 embedding_enabled,
                 keyword_count,
                 priority,
+                base_url_override,
             )
         elif ext_lower == '.png':
             from src.processing.image_processing.format_png_processing import process_png
@@ -437,6 +447,7 @@ def process_single_file(
                 embedding_enabled,
                 keyword_count,
                 priority,
+                base_url_override,
             )
         else:
             log_message(f"Unsupported file format for API: {ext_lower}")
@@ -578,6 +589,7 @@ def batch_process_files(
     priority="Details",
     bypass_api_key_limit=False,
     prompt_config=None,
+    base_url_override=None,
 ):
     if prompt_config is None:
         prompt_config = {}
@@ -749,6 +761,7 @@ def batch_process_files(
                             priority,
                             stop_event,
                             prompt_config,
+                            base_url_override,
                         )
                         batch_futures.append(future)
                         futures.append(future)
@@ -951,6 +964,7 @@ def batch_process_files(
                                     priority,
                                     stop_event,
                                     prompt_config,
+                                    base_url_override,
                                 )
                                 batch_retry_futures.append((future, input_path))
                                 retry_processed_files.add(input_path)

--- a/src/processing/error_classifier.py
+++ b/src/processing/error_classifier.py
@@ -1,0 +1,28 @@
+# RJ Auto Metadata
+# Copyright (C) 2026 Riiicil
+"""Helpers for translating provider-level error codes into pipeline statuses.
+
+Kept in a small dependency-free module so it can be imported from both the
+batch orchestrator and the per-format workers without forming an import
+cycle with ``src.processing.batch_processing``.
+"""
+from __future__ import annotations
+
+# Provider-level error codes that mean "user/config mistake" rather than a
+# transient API failure. Bursting through 5 retries on these only delays the
+# inevitable failure and burns rate-limit / connection budget.
+NON_RETRYABLE_ERROR_CODES = frozenset({
+    "custom_provider_no_base_url",
+    "custom_provider_no_model",
+    "openrouter_no_model",
+})
+
+
+def classify_metadata_error(error_code: str) -> str:
+    """Map an error code from ``provider_manager.get_metadata`` to a
+    pipeline status string. Structural/config errors are demoted to
+    ``failed_config`` (non-retryable); everything else is ``failed_api``.
+    """
+    if error_code in NON_RETRYABLE_ERROR_CODES:
+        return "failed_config"
+    return "failed_api"

--- a/src/processing/image_processing/format_jpg_jpeg_processing.py
+++ b/src/processing/image_processing/format_jpg_jpeg_processing.py
@@ -37,6 +37,7 @@ def process_jpg_jpeg(
     embedding_enabled=True,
     keyword_count="49",
     priority="Details",
+    base_url_override=None,
 ):
     filename = os.path.basename(input_path)
     initial_output_path = os.path.join(output_dir, filename)
@@ -87,6 +88,7 @@ def process_jpg_jpeg(
         keyword_count=keyword_count,
         priority=priority,
         is_vector_conversion=False,
+        base_url_override=base_url_override,
     )
     
     for temp_file in temp_files_created:

--- a/src/processing/image_processing/format_jpg_jpeg_processing.py
+++ b/src/processing/image_processing/format_jpg_jpeg_processing.py
@@ -21,6 +21,7 @@ import shutil
 from src.api import provider_manager
 from src.metadata.exif_writer import write_exif_with_exiftool
 from src.metadata.csv_exporter import write_to_platform_csvs
+from src.processing.error_classifier import classify_metadata_error
 from src.utils.compression import compress_image, get_temp_compression_folder
 from src.utils.file_utils import ensure_unique_title
 from src.utils.logging import log_message
@@ -103,7 +104,7 @@ def process_jpg_jpeg(
         return "stopped", None, None
     elif isinstance(metadata_result, dict) and "error" in metadata_result:
         log_message(f"API Error detail: {metadata_result['error']}")
-        return "failed_api", None, None
+        return classify_metadata_error(metadata_result["error"]), None, None
     elif isinstance(metadata_result, dict):
         metadata = metadata_result
     else:

--- a/src/processing/image_processing/format_png_processing.py
+++ b/src/processing/image_processing/format_png_processing.py
@@ -35,6 +35,7 @@ def process_png(
     embedding_enabled=True,
     keyword_count="49",
     priority="Details",
+    base_url_override=None,
 ):
     filename = os.path.basename(input_path)
     initial_output_path = os.path.join(output_dir, filename)
@@ -86,6 +87,7 @@ def process_png(
         keyword_count=keyword_count,
         priority=priority,
         is_vector_conversion=False,
+        base_url_override=base_url_override,
     )
     
     for temp_file in temp_files_created:

--- a/src/processing/image_processing/format_png_processing.py
+++ b/src/processing/image_processing/format_png_processing.py
@@ -20,6 +20,7 @@ import shutil
 
 from src.api import provider_manager
 from src.metadata.csv_exporter import write_to_platform_csvs
+from src.processing.error_classifier import classify_metadata_error
 from src.utils.compression import compress_image, get_temp_compression_folder
 from src.utils.logging import log_message
 
@@ -102,7 +103,7 @@ def process_png(
         return "stopped", None, None
     elif isinstance(metadata_result, dict) and "error" in metadata_result:
         log_message(f"API Error detail: {metadata_result['error']}")
-        return "failed_api", None, None
+        return classify_metadata_error(metadata_result["error"]), None, None
     elif isinstance(metadata_result, dict):
         metadata = metadata_result
     else:

--- a/src/processing/video_processing.py
+++ b/src/processing/video_processing.py
@@ -124,6 +124,7 @@ def process_video(
     embedding_enabled=True,
     keyword_count="49",
     priority="Details",
+    base_url_override=None,
 ):
     filename = os.path.basename(input_path)
     _, ext = os.path.splitext(filename)
@@ -222,6 +223,7 @@ def process_video(
         keyword_count=keyword_count,
         priority=priority,
         is_vector_conversion=False,
+        base_url_override=base_url_override,
     )
 
     all_frames_to_clean = list(set(extracted_frames + compressed_frames_to_clean))

--- a/src/processing/video_processing.py
+++ b/src/processing/video_processing.py
@@ -23,6 +23,7 @@ import cv2
 from src.api import provider_manager
 from src.metadata.csv_exporter import write_to_platform_csvs
 from src.metadata.exif_writer import write_exif_to_video  # Corrected import
+from src.processing.error_classifier import classify_metadata_error
 from src.utils.compression import compress_image, get_temp_compression_folder
 from src.utils.file_utils import WRITABLE_METADATA_VIDEO_EXTENSIONS  # Import the constant
 from src.utils.logging import log_message
@@ -238,7 +239,7 @@ def process_video(
         return "stopped", None, None
     elif isinstance(metadata_result, dict) and "error" in metadata_result:
         log_message(f"API Error detail: {metadata_result['error']}")
-        return "failed_api", None, None
+        return classify_metadata_error(metadata_result["error"]), None, None
     elif isinstance(metadata_result, dict):
         metadata = metadata_result
         metadata['keyword_count'] = keyword_count

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -340,7 +340,19 @@ class MetadataApp(ctk.CTk):
         self._log("Checking status of all API keys...", "info")
         try:
             provider_name = self.provider_var.get() if hasattr(self, "provider_var") else self.selected_provider
-            results = check_api_keys_status(api_keys, model=self.model_var.get(), provider=provider_name)
+            base_url_for_check = None
+            if provider_name == provider_manager.PROVIDER_CUSTOM and hasattr(self, "_custom_base_url_var"):
+                base_url_for_check = self._custom_base_url_var.get().strip() or None
+                if not base_url_for_check:
+                    self._log("Custom provider requires a Base URL before checking keys.", "warning")
+                    self.cek_api_button.configure(state=tk.NORMAL)
+                    return
+            results = check_api_keys_status(
+                api_keys,
+                model=self.model_var.get(),
+                provider=provider_name,
+                base_url_override=base_url_for_check,
+            )
             ok_keys = [k for k, (s, msg) in results.items() if s == 200]
             err_keys = [(k, s, msg) for k, (s, msg) in results.items() if s != 200]
             if len(ok_keys) == len(api_keys):
@@ -1554,6 +1566,36 @@ class MetadataApp(ctk.CTk):
                 "Please enter at least one API Key.")
             return
 
+        # Custom provider must have a Base URL or the request will go nowhere.
+        provider_for_validation = (
+            self.provider_var.get() if hasattr(self, "provider_var") else ""
+        )
+        if provider_for_validation == provider_manager.PROVIDER_CUSTOM:
+            custom_base_url = (
+                self._custom_base_url_var.get().strip()
+                if hasattr(self, "_custom_base_url_var") else ""
+            )
+            if not custom_base_url:
+                self._reset_ui_after_processing()
+                tk.messagebox.showwarning(
+                    "Base URL Required",
+                    "Custom provider requires a Base URL\n"
+                    "(for example, https://your-endpoint/v1).\n\n"
+                    "Enter a Base URL in the API panel before starting.",
+                )
+                return
+            selected_model_for_validation = (
+                self.model_var.get().strip() if hasattr(self, "model_var") else ""
+            )
+            if not selected_model_for_validation:
+                self._reset_ui_after_processing()
+                tk.messagebox.showwarning(
+                    "Model Required",
+                    "Custom provider requires a model selection.\n"
+                    "Use Fetch Models or enter a model id manually.",
+                )
+                return
+
         try:
             delay_sec = int(self.delay_var.get().strip() or "0")
             if delay_sec < 0:
@@ -1742,6 +1784,12 @@ class MetadataApp(ctk.CTk):
                 priority=priority,
                 bypass_api_key_limit=bypass_api_key_limit,
                 prompt_config=prompt_config,
+                base_url_override=(
+                    self._custom_base_url_var.get().strip()
+                    if provider_name == provider_manager.PROVIDER_CUSTOM
+                    and hasattr(self, "_custom_base_url_var")
+                    else None
+                ),
             )
 
             self.processed_count = result.get("processed_count", 0)

--- a/tests/api/test_custom_provider_smoke.py
+++ b/tests/api/test_custom_provider_smoke.py
@@ -4,27 +4,72 @@
 # Smoke test for custom-provider base_url plumbing.
 """Verify that ``base_url_override`` is threaded end-to-end.
 
-This test does not hit the network. It monkeypatches
-``openrouter_api.get_openrouter_metadata`` to record the kwargs it receives
-when invoked through ``provider_manager.get_metadata`` for the Custom
-provider, and also asserts the openrouter request endpoint is rebuilt from
-the override.
+These tests do not hit the network. They monkeypatch the
+``openrouter_api`` HTTP boundary to record what the rest of the system
+sends down to it, and assert the dispatcher / URL / error-classification
+behaviour stays correct as the contribution evolves.
 """
 from __future__ import annotations
 
-import os
 import sys
 import threading
-import types
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from src.api import openrouter_api, provider_manager  # noqa: E402
+from src.processing.error_classifier import classify_metadata_error  # noqa: E402
+
+
+def test_resolve_chat_endpoint_basic_cases() -> None:
+    resolve = openrouter_api._resolve_chat_endpoint
+    assert resolve(None) == openrouter_api.API_ENDPOINT
+    assert resolve("") == openrouter_api.API_ENDPOINT
+    assert resolve("   ") == openrouter_api.API_ENDPOINT
+    assert resolve("https://host/v1") == "https://host/v1/chat/completions"
+    assert resolve("https://host/v1/") == "https://host/v1/chat/completions"
+    assert resolve("https://host") == "https://host/chat/completions"
+    assert (
+        resolve("https://host/v1/chat/completions")
+        == "https://host/v1/chat/completions"
+    )
+    assert (
+        resolve("https://host/v1/chat/completions/")
+        == "https://host/v1/chat/completions"
+    )
+
+
+def test_resolve_chat_endpoint_preserves_query_and_fragment() -> None:
+    """Query strings and fragments must survive the normalisation step."""
+    resolve = openrouter_api._resolve_chat_endpoint
+    # Bare base URL with a key= query string (Azure-style auth via query)
+    assert (
+        resolve("https://host/v1?api-version=2024")
+        == "https://host/v1/chat/completions?api-version=2024"
+    )
+    # Already-final chat URL with a query string
+    assert (
+        resolve("https://host/v1/chat/completions?api-version=2024")
+        == "https://host/v1/chat/completions?api-version=2024"
+    )
+    # Path with fragment (rare but valid)
+    assert (
+        resolve("https://host/v1#frag")
+        == "https://host/v1/chat/completions#frag"
+    )
+
+
+def test_resolve_chat_endpoint_does_not_match_chat_completions_in_middle() -> None:
+    """``/chat/completions`` mid-path must NOT short-circuit normalisation."""
+    resolve = openrouter_api._resolve_chat_endpoint
+    # Hypothetical proxy that mounts the OpenAI surface under /api/.
+    out = resolve("https://host/v1/chat/completions/extra")
+    assert out == "https://host/v1/chat/completions/extra/chat/completions", out
 
 
 def test_custom_provider_threads_base_url() -> None:
+    """`provider_manager.get_metadata` must forward the override + model."""
     captured: dict = {}
 
     def fake_get_openrouter_metadata(image_path, api_key, stop_event, **kwargs):
@@ -57,7 +102,6 @@ def test_custom_provider_threads_base_url() -> None:
     assert result.get("title") == "ok", result
     assert captured["base_url_override"] == "https://example.test/v1", captured
     assert captured["selected_model_input"] == "my-org/my-model", captured
-    print("PASS: custom provider forwards base_url_override and model")
 
 
 def test_custom_provider_without_base_url_returns_error() -> None:
@@ -70,7 +114,6 @@ def test_custom_provider_without_base_url_returns_error() -> None:
         base_url_override="",
     )
     assert isinstance(result, dict) and result.get("error") == "custom_provider_no_base_url", result
-    print("PASS: missing base_url short-circuits with custom_provider_no_base_url")
 
 
 def test_custom_provider_without_model_returns_error() -> None:
@@ -83,28 +126,88 @@ def test_custom_provider_without_model_returns_error() -> None:
         base_url_override="https://example.test/v1",
     )
     assert isinstance(result, dict) and result.get("error") == "custom_provider_no_model", result
-    print("PASS: missing model short-circuits with custom_provider_no_model")
 
 
-def test_resolve_chat_endpoint() -> None:
-    resolve = openrouter_api._resolve_chat_endpoint
-    assert resolve(None) == openrouter_api.API_ENDPOINT
-    assert resolve("") == openrouter_api.API_ENDPOINT
-    assert resolve("   ") == openrouter_api.API_ENDPOINT
-    assert resolve("https://host/v1") == "https://host/v1/chat/completions"
-    assert resolve("https://host/v1/") == "https://host/v1/chat/completions"
-    assert (
-        resolve("https://host/v1/chat/completions")
-        == "https://host/v1/chat/completions"
+def test_check_api_keys_status_dispatches_custom_to_openrouter() -> None:
+    """Dispatcher must call openrouter_api.check_api_keys_status with the
+    override even though _PROVIDERS["Custom"]["module"] is None.
+
+    This guards the previous regression where the ``module is None`` guard
+    fired before the Custom branch and short-circuited every key to
+    "No module for this provider".
+    """
+    captured: dict = {}
+
+    def fake_check(api_keys, model=None, base_url_override=None):
+        captured["api_keys"] = list(api_keys)
+        captured["model"] = model
+        captured["base_url_override"] = base_url_override
+        return {key: (200, "OK") for key in api_keys}
+
+    original = openrouter_api.check_api_keys_status
+    openrouter_api.check_api_keys_status = fake_check
+    try:
+        result = provider_manager.check_api_keys_status(
+            provider_manager.PROVIDER_CUSTOM,
+            ["sk-test"],
+            model="my-model",
+            base_url_override="https://example.test/v1",
+        )
+    finally:
+        openrouter_api.check_api_keys_status = original
+
+    assert result == {"sk-test": (200, "OK")}, result
+    assert captured["base_url_override"] == "https://example.test/v1", captured
+    assert captured["model"] == "my-model", captured
+    assert captured["api_keys"] == ["sk-test"], captured
+
+
+def test_check_api_keys_status_custom_without_base_url_short_circuits() -> None:
+    result = provider_manager.check_api_keys_status(
+        provider_manager.PROVIDER_CUSTOM,
+        ["sk-1", "sk-2"],
+        model="my-model",
+        base_url_override="",
     )
-    assert (
-        resolve("https://host/v1/chat/completions/")
-        == "https://host/v1/chat/completions"
-    )
-    print("PASS: _resolve_chat_endpoint normalises bare base URLs and full chat URLs")
+    assert all(status == -1 for status, _ in result.values()), result
+    assert all("Base URL" in msg for _, msg in result.values()), result
 
 
-def test_openrouter_request_uses_override(monkeypatch_dummy=None) -> None:
+def test_classify_metadata_error_demotes_config_errors() -> None:
+    """Structural/config errors must not be classified as retryable failures.
+
+    They map to the non-retryable ``failed_config`` status so the auto-retry
+    loop does not burn 5 attempts on errors the user has to fix manually.
+    """
+    assert classify_metadata_error("custom_provider_no_base_url") == "failed_config"
+    assert classify_metadata_error("custom_provider_no_model") == "failed_config"
+    assert classify_metadata_error("openrouter_no_model") == "failed_config"
+    # Non-structural errors keep retry semantics.
+    assert classify_metadata_error("http_500") == "failed_api"
+    assert classify_metadata_error("invalid_json") == "failed_api"
+    assert classify_metadata_error("openrouter_max_retries") == "failed_api"
+
+
+def test_failed_config_is_non_retryable() -> None:
+    """``failed_config`` must be in NON_RETRYABLE_STATUSES.
+
+    We don't import ``batch_processing`` directly because that module pulls
+    runtime-only dependencies (cv2, portalocker, etc.). Instead we read the
+    file and assert on the static set membership.
+    """
+    bp_path = PROJECT_ROOT / "src" / "processing" / "batch_processing.py"
+    source = bp_path.read_text(encoding="utf-8")
+    # Locate the NON_RETRYABLE_STATUSES literal and assert failed_config is in it.
+    marker = "NON_RETRYABLE_STATUSES = {"
+    idx = source.find(marker)
+    assert idx != -1, "NON_RETRYABLE_STATUSES literal not found"
+    end = source.find("}", idx)
+    block = source[idx:end]
+    assert '"failed_config"' in block, block
+
+
+def test_openrouter_request_uses_override() -> None:
+    """End-to-end smoke: HTTP call lands on the overridden host."""
     captured_url: list[str] = []
 
     class FakeResponse:
@@ -134,7 +237,6 @@ def test_openrouter_request_uses_override(monkeypatch_dummy=None) -> None:
         captured_url.append(url)
         return FakeResponse()
 
-    # Patch encode + requests.post so we don't read disk or hit network.
     original_encode = openrouter_api._encode_image
     original_validate = openrouter_api._validate_images
     original_post = openrouter_api.requests.post
@@ -154,19 +256,33 @@ def test_openrouter_request_uses_override(monkeypatch_dummy=None) -> None:
         openrouter_api._validate_images = original_validate
         openrouter_api.requests.post = original_post
 
-    assert isinstance(result, dict), result
-    assert "error" not in result, result
+    assert isinstance(result, dict) and "error" not in result, result
     assert captured_url, "no HTTP call captured"
     assert captured_url[0] == "https://example.test/v1/chat/completions", captured_url
-    print(f"PASS: openrouter posted to overridden URL {captured_url[0]}")
 
 
+# ---------------------------------------------------------------------------
+# Direct-execution entrypoint (so this file works with both `pytest` and
+# `python tests/api/test_custom_provider_smoke.py`). pytest picks up the
+# `test_*` functions automatically.
+# ---------------------------------------------------------------------------
 def main() -> int:
-    test_resolve_chat_endpoint()
-    test_custom_provider_threads_base_url()
-    test_custom_provider_without_base_url_returns_error()
-    test_custom_provider_without_model_returns_error()
-    test_openrouter_request_uses_override()
+    cases = [
+        ("resolve_chat_endpoint basic", test_resolve_chat_endpoint_basic_cases),
+        ("resolve_chat_endpoint preserves query/fragment", test_resolve_chat_endpoint_preserves_query_and_fragment),
+        ("resolve_chat_endpoint mid-path", test_resolve_chat_endpoint_does_not_match_chat_completions_in_middle),
+        ("custom provider threads base_url", test_custom_provider_threads_base_url),
+        ("custom provider missing base_url", test_custom_provider_without_base_url_returns_error),
+        ("custom provider missing model", test_custom_provider_without_model_returns_error),
+        ("check_api_keys_status dispatches Custom", test_check_api_keys_status_dispatches_custom_to_openrouter),
+        ("check_api_keys_status Custom missing URL", test_check_api_keys_status_custom_without_base_url_short_circuits),
+        ("classify_metadata_error demotion", test_classify_metadata_error_demotes_config_errors),
+        ("failed_config is non-retryable", test_failed_config_is_non_retryable),
+        ("openrouter request uses override", test_openrouter_request_uses_override),
+    ]
+    for label, fn in cases:
+        fn()
+        print(f"PASS: {label}")
     print("\nAll custom-provider smoke tests passed.")
     return 0
 

--- a/tests/api/test_custom_provider_smoke.py
+++ b/tests/api/test_custom_provider_smoke.py
@@ -1,0 +1,175 @@
+# RJ Auto Metadata
+# Copyright (C) 2026 Riiicil
+#
+# Smoke test for custom-provider base_url plumbing.
+"""Verify that ``base_url_override`` is threaded end-to-end.
+
+This test does not hit the network. It monkeypatches
+``openrouter_api.get_openrouter_metadata`` to record the kwargs it receives
+when invoked through ``provider_manager.get_metadata`` for the Custom
+provider, and also asserts the openrouter request endpoint is rebuilt from
+the override.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import types
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.api import openrouter_api, provider_manager  # noqa: E402
+
+
+def test_custom_provider_threads_base_url() -> None:
+    captured: dict = {}
+
+    def fake_get_openrouter_metadata(image_path, api_key, stop_event, **kwargs):
+        captured["image_path"] = image_path
+        captured["api_key"] = api_key
+        captured.update(kwargs)
+        return {
+            "title": "ok",
+            "description": "ok",
+            "tags": ["alpha", "beta"],
+            "as_category": "",
+            "ss_category": "",
+        }
+
+    original = openrouter_api.get_openrouter_metadata
+    openrouter_api.get_openrouter_metadata = fake_get_openrouter_metadata
+    try:
+        result = provider_manager.get_metadata(
+            provider=provider_manager.PROVIDER_CUSTOM,
+            image_path="/tmp/dummy.jpg",
+            api_key="sk-test",
+            stop_event=threading.Event(),
+            selected_model="my-org/my-model",
+            base_url_override="https://example.test/v1",
+        )
+    finally:
+        openrouter_api.get_openrouter_metadata = original
+
+    assert isinstance(result, dict), result
+    assert result.get("title") == "ok", result
+    assert captured["base_url_override"] == "https://example.test/v1", captured
+    assert captured["selected_model_input"] == "my-org/my-model", captured
+    print("PASS: custom provider forwards base_url_override and model")
+
+
+def test_custom_provider_without_base_url_returns_error() -> None:
+    result = provider_manager.get_metadata(
+        provider=provider_manager.PROVIDER_CUSTOM,
+        image_path="/tmp/dummy.jpg",
+        api_key="sk-test",
+        stop_event=threading.Event(),
+        selected_model="my-org/my-model",
+        base_url_override="",
+    )
+    assert isinstance(result, dict) and result.get("error") == "custom_provider_no_base_url", result
+    print("PASS: missing base_url short-circuits with custom_provider_no_base_url")
+
+
+def test_custom_provider_without_model_returns_error() -> None:
+    result = provider_manager.get_metadata(
+        provider=provider_manager.PROVIDER_CUSTOM,
+        image_path="/tmp/dummy.jpg",
+        api_key="sk-test",
+        stop_event=threading.Event(),
+        selected_model="",
+        base_url_override="https://example.test/v1",
+    )
+    assert isinstance(result, dict) and result.get("error") == "custom_provider_no_model", result
+    print("PASS: missing model short-circuits with custom_provider_no_model")
+
+
+def test_resolve_chat_endpoint() -> None:
+    resolve = openrouter_api._resolve_chat_endpoint
+    assert resolve(None) == openrouter_api.API_ENDPOINT
+    assert resolve("") == openrouter_api.API_ENDPOINT
+    assert resolve("   ") == openrouter_api.API_ENDPOINT
+    assert resolve("https://host/v1") == "https://host/v1/chat/completions"
+    assert resolve("https://host/v1/") == "https://host/v1/chat/completions"
+    assert (
+        resolve("https://host/v1/chat/completions")
+        == "https://host/v1/chat/completions"
+    )
+    assert (
+        resolve("https://host/v1/chat/completions/")
+        == "https://host/v1/chat/completions"
+    )
+    print("PASS: _resolve_chat_endpoint normalises bare base URLs and full chat URLs")
+
+
+def test_openrouter_request_uses_override(monkeypatch_dummy=None) -> None:
+    captured_url: list[str] = []
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                '{"title":"t","description":"d",'
+                                '"keywords":["k1","k2"],'
+                                '"adobe_stock_category":"",'
+                                '"shutterstock_category":""}'
+                            )
+                        }
+                    }
+                ]
+            }
+
+        @property
+        def text(self):
+            return ""
+
+    def fake_post(url, headers=None, json=None, timeout=None, **_):
+        captured_url.append(url)
+        return FakeResponse()
+
+    # Patch encode + requests.post so we don't read disk or hit network.
+    original_encode = openrouter_api._encode_image
+    original_validate = openrouter_api._validate_images
+    original_post = openrouter_api.requests.post
+    openrouter_api._encode_image = lambda path: ("ZmFrZQ==", "image/jpeg")
+    openrouter_api._validate_images = lambda images: (True, None)
+    openrouter_api.requests.post = fake_post
+    try:
+        result = openrouter_api.get_openrouter_metadata(
+            image_path="C:/fake/path.jpg",
+            api_key="sk-test",
+            stop_event=threading.Event(),
+            selected_model_input="my-model",
+            base_url_override="https://example.test/v1",
+        )
+    finally:
+        openrouter_api._encode_image = original_encode
+        openrouter_api._validate_images = original_validate
+        openrouter_api.requests.post = original_post
+
+    assert isinstance(result, dict), result
+    assert "error" not in result, result
+    assert captured_url, "no HTTP call captured"
+    assert captured_url[0] == "https://example.test/v1/chat/completions", captured_url
+    print(f"PASS: openrouter posted to overridden URL {captured_url[0]}")
+
+
+def main() -> int:
+    test_resolve_chat_endpoint()
+    test_custom_provider_threads_base_url()
+    test_custom_provider_without_base_url_returns_error()
+    test_custom_provider_without_model_returns_error()
+    test_openrouter_request_uses_override()
+    print("\nAll custom-provider smoke tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Custom provider was completely unusable: every file failed with
`Custom provider requires a base_url_override.` and auto-retry exhausted
4 rounds, even when the user filled in a Base URL in the UI and the
"cek api" button validated.

Two root causes existed and were masking each other:

1. **UI never forwarded the user's Base URL to the worker pipeline.**
   The value lived on `self._custom_base_url_var` and was used only for
   `fetch_models`. The chain
   `batch_process_files → process_single_file → process_jpg_jpeg/png/video/vector → provider_manager.get_metadata`
   never received it, so the `PROVIDER_CUSTOM` branch always
   short-circuited to `{"error": "custom_provider_no_base_url"}`.

2. **`openrouter_api` was hardcoded to OpenRouter.** Even with a
   populated override, both `get_openrouter_metadata` and
   `check_api_keys_status` did `requests.post(API_ENDPOINT, ...)` with
   `API_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"`.
   The user's endpoint would have been ignored.

## Changes

- **`src/api/openrouter_api.py`** — accepts `base_url_override`, builds
  the chat-completions URL via a small `_resolve_chat_endpoint` helper
  using `urllib.parse.urlsplit` (preserves query strings and fragments,
  matches `/chat/completions` only at the trailing path component), and
  skips OpenRouter-proprietary `HTTP-Referer` / `X-Title` headers when
  an override is in use.
- **`src/api/provider_manager.py`** — `get_metadata` forwards
  `base_url_override` to `openrouter_api` for the Custom branch and
  guards against missing model (`custom_provider_no_model`).
  `check_api_keys_status` now reaches the Custom branch (the previous
  ordering let `module is None` fire first since
  `_PROVIDERS["Custom"]["module"]` is `None`).
- **`src/api/api_key_checker.py`** — propagates `base_url_override`.
- **Worker pipeline** (`batch_processing.py`, `video_processing.py`,
  `format_jpg_jpeg_processing.py`, `format_png_processing.py`) —
  threads `base_url_override` end-to-end, including both
  `executor.submit` call sites in the initial and retry batches.
- **`src/ui/app.py`** — reads `_custom_base_url_var` when starting a
  run and when checking API keys, validates Base URL + model up-front
  with a friendly dialog when either is missing for Custom.
- **New `src/processing/error_classifier.py`** — small dependency-free
  helper that maps structural-config error codes
  (`custom_provider_no_base_url`, `custom_provider_no_model`,
  `openrouter_no_model`) to the new non-retryable status
  `failed_config`, so user-config mistakes don't burn 5 retries each.
- **Tests** — `tests/api/test_custom_provider_smoke.py` covers
  endpoint resolution (incl. query/fragment, mid-path edge cases),
  the threaded override, missing-base-url and missing-model guards,
  the dispatcher's Custom path, error-classifier demotion, and the
  end-to-end HTTP URL hitting the override host.

## Repro (before this PR)

1. Provider = Custom, Base URL filled, Model selected, valid API key.
2. Drop a file in input folder, hit Start.
3. Every file fails with `Custom provider requires a base_url_override.`,
   then 4 retry rounds also fail.

## Verification (after this PR)

- Direct dispatcher reproduction:
  ```
  $ python -c "from src.api import provider_manager as pm; print(pm.check_api_keys_status(pm.PROVIDER_CUSTOM, ['sk-test'], model='m', base_url_override='https://example.test/v1'))"
  ```
  Now reaches `https://example.test/v1/chat/completions` (network error
  from the dummy host, not a guard short-circuit).

- Smoke tests (no network, no extra deps):
  ```
  $ python tests/api/test_custom_provider_smoke.py
  PASS: resolve_chat_endpoint basic
  PASS: resolve_chat_endpoint preserves query/fragment
  PASS: resolve_chat_endpoint mid-path
  PASS: custom provider threads base_url
  PASS: custom provider missing base_url
  PASS: custom provider missing model
  PASS: check_api_keys_status dispatches Custom
  PASS: check_api_keys_status Custom missing URL
  PASS: classify_metadata_error demotion
  PASS: failed_config is non-retryable
  PASS: openrouter request uses override
  All custom-provider smoke tests passed.
  ```

## Backward compatibility

- `base_url_override=None` for any non-Custom provider keeps the
  existing OpenRouter request path bit-for-bit identical (same URL,
  same headers, same default model `openai/gpt-4.1`).
- The other 7 providers (Gemini, OpenAI, OpenRouter, Groq, KoboiLLM,
  Mistral, Blackbox) are untouched.
- Public function signatures only **add** keyword-only parameters at
  the end (`base_url_override=None`); existing positional callers keep
  working.

## Notes for reviewer

- `src/processing/batch_processing.py` shows large +/- in the diff stat
  due to CRLF normalisation on commit; the actual logic delta is ~14
  lines threading `base_url_override`. Use `git diff -w` to ignore
  whitespace.
- This branch was developed against `dev` per `docs/GIT_POLICY.md`
  and follows the `task/<name>` naming convention.

## Out of scope (intentionally deferred)

- Promoting the literal `"openai/gpt-4.1"` default model to a module
  constant.
- Per-provider header pre-computation outside the request loop
  (micro-optimisation).
- Moving `_DEFAULT_CHAT_PATH` to a shared module — only one consumer at
  the moment.

## Files changed

```
src/api/api_key_checker.py
src/api/openrouter_api.py
src/api/provider_manager.py
src/processing/batch_processing.py
src/processing/error_classifier.py        (new)
src/processing/image_processing/format_jpg_jpeg_processing.py
src/processing/image_processing/format_png_processing.py
src/processing/video_processing.py
src/ui/app.py
tests/api/test_custom_provider_smoke.py   (new)
```
